### PR TITLE
Add constants with predefined visibility scope

### DIFF
--- a/src/Support/Classify.php
+++ b/src/Support/Classify.php
@@ -35,7 +35,7 @@ class Classify
     {
         $value = Dumper::export($value);
 
-        return "\tconst $name = $value;\n";
+        return "\tpublic const $name = $value;\n";
     }
 
     /**


### PR DESCRIPTION
This PR will add constants visibility by default to follow https://www.php-fig.org/psr/psr-12/#43-properties-and-constants style guide